### PR TITLE
🔧 improve dependabot config for bun monorepo support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,57 @@ updates:
       prefix: ":arrow_upper_right: [patch]"
       include: "scope"
 
+  # Monorepo subconfigs for better Bun support
+  - package-ecosystem: "npm"
+    directory: "/packages/~/app/api"
+    schedule:
+      interval: "weekly"
+    labels:
+      - dependencies
+    commit-message:
+      prefix: ":arrow_upper_right: [patch]"
+      include: "scope"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/~/app/middleware"
+    schedule:
+      interval: "weekly"
+    labels:
+      - dependencies
+    commit-message:
+      prefix: ":arrow_upper_right: [patch]"
+      include: "scope"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/~/moderations/api"
+    schedule:
+      interval: "weekly"
+    labels:
+      - dependencies
+    commit-message:
+      prefix: ":arrow_upper_right: [patch]"
+      include: "scope"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/~/organizations/api"
+    schedule:
+      interval: "weekly"
+    labels:
+      - dependencies
+    commit-message:
+      prefix: ":arrow_upper_right: [patch]"
+      include: "scope"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/~/users/api"
+    schedule:
+      interval: "weekly"
+    labels:
+      - dependencies
+    commit-message:
+      prefix: ":arrow_upper_right: [patch]"
+      include: "scope"
+
   - package-ecosystem: "npm"
     directory: "/e2e"
     schedule:


### PR DESCRIPTION
<div align=center><img src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExaGp3NXZ0bHJnNjdwdGNzejNmcXNsZGwyZ3h0MzJtaWN2eGlmcWxpYyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xT9IgzoKnwFNmISR8I/giphy.gif" /></div>

---

## Problem

Dependabot was not updating `bun.lock` files in PRs, only updating `package.json` files. This happens because Dependabot doesn't natively support Bun's lockfile format yet.

## Solution

Added monorepo subconfigs to improve Bun support based on community workaround from GitHub issue [dependabot/dependabot-core#6528](https://github.com/dependabot/dependabot-core/issues/6528).

### Changes Made

- Added individual directory configurations for key packages in the monorepo
- Kept existing root configuration for main dependencies
- Used `package-ecosystem: "npm"` which works with Bun projects
- Targeted specific subdirectories where important dependencies live

### Sources

- **GitHub Issue**: [Add support for Bun #6528](https://github.com/dependabot/dependabot-core/issues/6528)
- **Workaround Comment**: [DenIrkhin's comment about monorepo subconfigs](https://github.com/dependabot/dependabot-core/issues/6528#issuecomment-1738577756)

This approach should help Dependabot better understand our monorepo structure and potentially improve how it handles lockfile updates.

🤖 Generated with [Claude Code](https://claude.ai/code)