### PR TITLE
🚑 manually revert commit fb97892 to fix the verification type and the front

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,11 +56,8 @@
         "consola": "3.4.2",
         "drizzle-orm": "0.41.0",
         "hono": "4.8.4",
-        "htmx-ext-debug": "2.0.1",
-        "htmx-ext-include-vals": "2.0.1",
-        "htmx-ext-sse": "2.2.3",
         "htmx.ext...chunked-transfer": "2.1.0",
-        "htmx.org": "2.0.0",
+        "htmx.org": "1.9.12",
         "hyperscript.org": "0.9.14",
         "ts-pattern": "5.7.1",
         "youch": "3.3.4",
@@ -1355,15 +1352,9 @@
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
-    "htmx-ext-debug": ["htmx-ext-debug@2.0.1", "", { "dependencies": { "htmx.org": "^2.0.2" } }, "sha512-GipbV220uTYdRrTzL+pK/Lbus3z167M6Ds6WnliCItIwsyK5qIFK8GPl6QIAaonf6+8sVif7rkxz/VIXUWdlFA=="],
-
-    "htmx-ext-include-vals": ["htmx-ext-include-vals@2.0.1", "", { "dependencies": { "htmx.org": "^2.0.2" } }, "sha512-54+CaKB8VZPdgNT71MkQepqiNX134jtDBmH4+FY9dUuBwbSx5YXjzE1vtO6XfXJC8FPiwsgezJO/qMD/GvEGSQ=="],
-
-    "htmx-ext-sse": ["htmx-ext-sse@2.2.3", "", { "dependencies": { "htmx.org": "^2.0.2" } }, "sha512-DDahTngA+XSUeX4/EFAzAGDkvY8pdr/FmelHzag0FvZpUOh41G08P1fwp+jfFZCQphkA7/z06l90FN4iyD6O2w=="],
-
     "htmx.ext...chunked-transfer": ["htmx.ext...chunked-transfer@2.1.0", "", {}, "sha512-b3o+gZS2EH8XTgct+gE8iw3i761jttj1vz1PQev3cho+Fr2Q3cDX9u8/Z7Tv5FxZljgx3hlDxHeOO0pWWOOXnw=="],
 
-    "htmx.org": ["htmx.org@2.0.0", "", {}, "sha512-N0r1VjrqeCpig0mTi2/sooDZBeQlp1RBohnWQ/ufqc7ICaI0yjs04fNGhawm6+/HWhJFlcXn8MqOjWI9QGG2lQ=="],
+    "htmx.org": ["htmx.org@1.9.12", "", {}, "sha512-VZAohXyF7xPGS52IM8d1T1283y+X4D+Owf3qY1NZ9RuBypyu9l8cGsxUMAG5fEAb/DhT7rDoJ9Hpu5/HxFD3cw=="],
 
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
@@ -2050,12 +2041,6 @@
     "glob/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
 
     "hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
-    "htmx-ext-debug/htmx.org": ["htmx.org@2.0.6", "", {}, "sha512-7ythjYneGSk3yCHgtCnQeaoF+D+o7U2LF37WU3O0JYv3gTZSicdEFiI/Ai/NJyC5ZpYJWMpUb11OC5Lr6AfAqA=="],
-
-    "htmx-ext-include-vals/htmx.org": ["htmx.org@2.0.6", "", {}, "sha512-7ythjYneGSk3yCHgtCnQeaoF+D+o7U2LF37WU3O0JYv3gTZSicdEFiI/Ai/NJyC5ZpYJWMpUb11OC5Lr6AfAqA=="],
-
-    "htmx-ext-sse/htmx.org": ["htmx.org@2.0.6", "", {}, "sha512-7ythjYneGSk3yCHgtCnQeaoF+D+o7U2LF37WU3O0JYv3gTZSicdEFiI/Ai/NJyC5ZpYJWMpUb11OC5Lr6AfAqA=="],
 
     "lightningcss/detect-libc": ["detect-libc@2.0.4", "", {}, "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="],
 

--- a/packages/~/app/api/package.json
+++ b/packages/~/app/api/package.json
@@ -24,11 +24,8 @@
     "consola": "3.4.2",
     "drizzle-orm": "0.41.0",
     "hono": "4.8.4",
-    "htmx-ext-debug": "2.0.1",
-    "htmx-ext-include-vals": "2.0.1",
-    "htmx-ext-sse": "2.2.3",
     "htmx.ext...chunked-transfer": "2.1.0",
-    "htmx.org": "2.0.0",
+    "htmx.org": "1.9.12",
     "hyperscript.org": "0.9.14",
     "ts-pattern": "5.7.1",
     "youch": "3.3.4"

--- a/packages/~/app/layout/src/__snapshots__/main.test.tsx.snap
+++ b/packages/~/app/layout/src/__snapshots__/main.test.tsx.snap
@@ -55,16 +55,12 @@ exports[`Main Layout 1`] = `
           href="/node_modules/animate.css/source/bouncing_entrances/bounceIn.css"
         />
 
-        <!--  -->
-
-        <link
-                rel="stylesheet"
-                href="/node_modules/@gouvfr/dsfr/dist/dsfr/dsfr.css"
-              />
-              <link
-                rel="stylesheet"
-                href="/node_modules/@gouvfr/dsfr/dist/utility/utility.min.css"
-              />
+        <style>
+              @import "/node_modules/@gouvfr/dsfr/dist/dsfr/dsfr.css"
+                layer(dsfr);
+              @import "/node_modules/@gouvfr/dsfr/dist/utility/utility.css"
+                layer(dsfr-utility);
+            </style>
 
         <!--  -->
 
@@ -135,7 +131,8 @@ exports[`Main Layout 1`] = `
 
       <script
             nonce="nonce"
-            src="/node_modules/htmx.org/dist/htmx.min.js"
+            src="/node_modules/htmx.org/dist/htmx.js"
+            type="module"
           ></script>
 
       <meta
@@ -147,12 +144,12 @@ exports[`Main Layout 1`] = `
 
       <script
         nonce="nonce"
-        src="/node_modules/htmx-ext-include-vals/include-vals.js"
+        src="/node_modules/htmx.org/dist/ext/include-vals.js"
         type="module"
       ></script>
       <script
         nonce="nonce"
-        src="/node_modules/htmx-ext-sse/dist/sse.js"
+        src="/node_modules/htmx.org/dist/ext/sse.js"
         type="module"
       ></script>
       <script
@@ -164,9 +161,14 @@ exports[`Main Layout 1`] = `
       <!--  -->
 
       <script
-            nonce="nonce"
-            src="/node_modules/hyperscript.org/dist/_hyperscript.min.js"
-          ></script> 
+              nonce="nonce"
+              src="/node_modules/hyperscript.org/dist/_hyperscript.js"
+            ></script>
+
+            <script
+              nonce="nonce"
+              src="/node_modules/hyperscript.org/dist/hdb.js"
+            ></script>
       <script
         nonce="nonce"
         src="/node_modules/hyperscript.org/dist/template.js"

--- a/packages/~/app/layout/src/__snapshots__/root.test.tsx.snap
+++ b/packages/~/app/layout/src/__snapshots__/root.test.tsx.snap
@@ -55,16 +55,12 @@ exports[`development 1`] = `
           href="/assets/ASSETS_PATH/node_modules/animate.css/source/bouncing_entrances/bounceIn.css"
         />
 
-        <!--  -->
-
-        <link
-                rel="stylesheet"
-                href="/assets/ASSETS_PATH/node_modules/@gouvfr/dsfr/dist/dsfr/dsfr.css"
-              />
-              <link
-                rel="stylesheet"
-                href="/assets/ASSETS_PATH/node_modules/@gouvfr/dsfr/dist/utility/utility.min.css"
-              />
+        <style>
+              @import "/assets/ASSETS_PATH/node_modules/@gouvfr/dsfr/dist/dsfr/dsfr.css"
+                layer(dsfr);
+              @import "/assets/ASSETS_PATH/node_modules/@gouvfr/dsfr/dist/utility/utility.css"
+                layer(dsfr-utility);
+            </style>
 
         <!--  -->
 
@@ -133,6 +129,7 @@ exports[`development 1`] = `
       <script
             nonce="nonce"
             src="/assets/ASSETS_PATH/node_modules/htmx.org/dist/htmx.js"
+            type="module"
           ></script>
 
       <meta
@@ -144,12 +141,12 @@ exports[`development 1`] = `
 
       <script
         nonce="nonce"
-        src="/assets/ASSETS_PATH/node_modules/htmx-ext-include-vals/include-vals.js"
+        src="/assets/ASSETS_PATH/node_modules/htmx.org/dist/ext/include-vals.js"
         type="module"
       ></script>
       <script
         nonce="nonce"
-        src="/assets/ASSETS_PATH/node_modules/htmx-ext-sse/dist/sse.js"
+        src="/assets/ASSETS_PATH/node_modules/htmx.org/dist/ext/sse.js"
         type="module"
       ></script>
       <script
@@ -232,16 +229,12 @@ exports[`production 1`] = `
           href="/assets/ASSETS_PATH/node_modules/animate.css/source/bouncing_entrances/bounceIn.css"
         />
 
-        <!--  -->
-
-        <link
-                rel="stylesheet"
-                href="/assets/ASSETS_PATH/node_modules/@gouvfr/dsfr/dist/dsfr/dsfr.min.css"
-              />
-              <link
-                rel="stylesheet"
-                href="/assets/ASSETS_PATH/node_modules/@gouvfr/dsfr/dist/utility/utility.min.css"
-              />
+        <style>
+              @import "/assets/ASSETS_PATH/node_modules/@gouvfr/dsfr/dist/dsfr/dsfr.min.css"
+                layer(dsfr);
+              @import "/assets/ASSETS_PATH/node_modules/@gouvfr/dsfr/dist/utility/utility.min.css"
+                layer(dsfr-utility);
+            </style>
 
         <!--  -->
 
@@ -310,6 +303,7 @@ exports[`production 1`] = `
       <script
             nonce="nonce"
             src="/assets/ASSETS_PATH/node_modules/htmx.org/dist/htmx.min.js"
+            type="module"
           ></script>
 
       <meta
@@ -321,12 +315,12 @@ exports[`production 1`] = `
 
       <script
         nonce="nonce"
-        src="/assets/ASSETS_PATH/node_modules/htmx-ext-include-vals/include-vals.js"
+        src="/assets/ASSETS_PATH/node_modules/htmx.org/dist/ext/include-vals.js"
         type="module"
       ></script>
       <script
         nonce="nonce"
-        src="/assets/ASSETS_PATH/node_modules/htmx-ext-sse/dist/sse.js"
+        src="/assets/ASSETS_PATH/node_modules/htmx.org/dist/ext/sse.js"
         type="module"
       ></script>
       <script

--- a/packages/~/app/layout/src/root.ts
+++ b/packages/~/app/layout/src/root.ts
@@ -73,25 +73,19 @@ export function Root_Layout({ children }: PropsWithChildren) {
           href="${config.ASSETS_PATH}/node_modules/animate.css/source/bouncing_entrances/bounceIn.css"
         />
 
-        <!--  -->
-
         ${config.NODE_ENV === "production"
-          ? html`<link
-                rel="stylesheet"
-                href="${config.ASSETS_PATH}/node_modules/@gouvfr/dsfr/dist/dsfr/dsfr.min.css"
-              />
-              <link
-                rel="stylesheet"
-                href="${config.ASSETS_PATH}/node_modules/@gouvfr/dsfr/dist/utility/utility.min.css"
-              />`
-          : html`<link
-                rel="stylesheet"
-                href="${config.ASSETS_PATH}/node_modules/@gouvfr/dsfr/dist/dsfr/dsfr.css"
-              />
-              <link
-                rel="stylesheet"
-                href="${config.ASSETS_PATH}/node_modules/@gouvfr/dsfr/dist/utility/utility.min.css"
-              />`}
+          ? html`<style>
+              @import "${config.ASSETS_PATH}/node_modules/@gouvfr/dsfr/dist/dsfr/dsfr.min.css"
+                layer(dsfr);
+              @import "${config.ASSETS_PATH}/node_modules/@gouvfr/dsfr/dist/utility/utility.min.css"
+                layer(dsfr-utility);
+            </style>`
+          : html`<style>
+              @import "${config.ASSETS_PATH}/node_modules/@gouvfr/dsfr/dist/dsfr/dsfr.css"
+                layer(dsfr);
+              @import "${config.ASSETS_PATH}/node_modules/@gouvfr/dsfr/dist/utility/utility.css"
+                layer(dsfr-utility);
+            </style>`}
 
         <!--  -->
 
@@ -159,14 +153,16 @@ export function Root_Layout({ children }: PropsWithChildren) {
 
       <!--  -->
 
-      ${config.NODE_ENV === "development"
+      ${config.NODE_ENV === "production"
         ? html`<script
             nonce="${nonce}"
-            src="${config.ASSETS_PATH}/node_modules/htmx.org/dist/htmx.js"
+            src="${config.ASSETS_PATH}/node_modules/htmx.org/dist/htmx.min.js"
+            type="module"
           ></script>`
         : html`<script
             nonce="${nonce}"
-            src="${config.ASSETS_PATH}/node_modules/htmx.org/dist/htmx.min.js"
+            src="${config.ASSETS_PATH}/node_modules/htmx.org/dist/htmx.js"
+            type="module"
           ></script>`}
 
       <meta
@@ -182,18 +178,19 @@ export function Root_Layout({ children }: PropsWithChildren) {
       ${config.DEPLOY_ENV === "preview"
         ? html`<script
             nonce="${nonce}"
-            src="${config.ASSETS_PATH}/node_modules/htmx-ext-debug/debug.js"
+            src="${config.ASSETS_PATH}/node_modules/htmx.org/dist/ext/debug.js"
+            type="module"
           ></script>`
         : ""}
 
       <script
         nonce="${nonce}"
-        src="${config.ASSETS_PATH}/node_modules/htmx-ext-include-vals/include-vals.js"
+        src="${config.ASSETS_PATH}/node_modules/htmx.org/dist/ext/include-vals.js"
         type="module"
       ></script>
       <script
         nonce="${nonce}"
-        src="${config.ASSETS_PATH}/node_modules/htmx-ext-sse/dist/sse.js"
+        src="${config.ASSETS_PATH}/node_modules/htmx.org/dist/ext/sse.js"
         type="module"
       ></script>
       <script
@@ -204,8 +201,12 @@ export function Root_Layout({ children }: PropsWithChildren) {
 
       <!--  -->
 
-      ${config.NODE_ENV === "development"
+      ${config.NODE_ENV === "production"
         ? html`<script
+            nonce="${nonce}"
+            src="${config.ASSETS_PATH}/node_modules/hyperscript.org/dist/_hyperscript.min.js"
+          ></script> `
+        : html`<script
               nonce="${nonce}"
               src="${config.ASSETS_PATH}/node_modules/hyperscript.org/dist/_hyperscript.js"
             ></script>
@@ -213,11 +214,7 @@ export function Root_Layout({ children }: PropsWithChildren) {
             <script
               nonce="${nonce}"
               src="${config.ASSETS_PATH}/node_modules/hyperscript.org/dist/hdb.js"
-            ></script>`
-        : html`<script
-            nonce="${nonce}"
-            src="${config.ASSETS_PATH}/node_modules/hyperscript.org/dist/_hyperscript.min.js"
-          ></script> `}
+            ></script>`}
       <script
         nonce="${nonce}"
         src="${config.ASSETS_PATH}/node_modules/hyperscript.org/dist/template.js"


### PR DESCRIPTION
revert #962 

ce que ça casse : 

**Le front :** 
<img width="1255" height="332" alt="image" src="https://github.com/user-attachments/assets/6892d3eb-71db-4454-bf5f-775a637e47f9" />

**Les verifications types ne sont plus cliquables:**
<img width="650" height="284" alt="image" src="https://github.com/user-attachments/assets/22f1d399-2cbf-44ac-b6f1-63c91bfb1d98" />

