### PR TITLE
test(e2e): add verification type selection test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -96,5 +96,6 @@ jobs:
           - moderations/handle_big_organization.feature
           - moderations/handle_duplicate_requests.feature
           - moderations/reprocess_completed_moderation.feature
+          - moderations/select_verification_type.feature
           - organizations
           - users

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,6 +20,11 @@ jobs:
         working-directory: "e2e"
 
     steps:
+      - name: Set artifact name
+        id: artifact
+        run: echo "name=$(echo '${{ matrix.e2e_test }}' | sed 's/\//-/g')" >> $GITHUB_OUTPUT
+        working-directory: "."
+
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -71,18 +76,18 @@ jobs:
         if: failure()
         with:
           compression-level: 9
-          name: cypress-${{ matrix.e2e_test }}-screenshots
+          name: cypress-${{ steps.artifact.outputs.name }}-screenshots
           path: e2e/cypress/screenshots
-          spec: features/${{ matrix.e2e_test }}
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
           compression-level: 9
-          name: cypress-${{ matrix.e2e_test }}-videos
+          name: cypress-${{ steps.artifact.outputs.name }}-videos
           path: e2e/cypress/videos
 
     strategy:
+      max-parallel: 6
       matrix:
         e2e_test:
           - auth

--- a/e2e/features/moderations/select_verification_type.feature
+++ b/e2e/features/moderations/select_verification_type.feature
@@ -1,0 +1,39 @@
+#language: fr
+Fonctionnalité: Sélectionner un type de vérification lors de l'acceptation
+
+  Contexte:
+    Soit une base de données nourrie au grain
+    Et un faux serveur "identite.proconnect.gouv.fr"
+    Quand je navigue sur la page
+    Et je clique sur le bouton "ProConnect"
+    Alors je vois "Liste des moderations"
+    Quand je vais à l'intérieur de la rangée nommée "Modération a traiter de Jean Bon pour 51935970700022"
+    Et je clique sur "➡️"
+    Et je dois voir le titre de page "Modération a traiter de Jean Bon pour 51935970700022"
+    Et je réinitialise le contexte
+    Et je clique sur "✅ Accepter"
+
+  Plan du Scénario: Sélectionner différents types de vérification
+    Alors je vois "A propos de jeanbon@yopmail.com pour l'organisation Abracadabra, je valide :"
+    Soit je vais à l'intérieur du dialogue nommé "la modale de validation"
+    Quand je clique sur "<type_verification>"
+    Quand je clique sur "Terminer"
+    Et je réinitialise le contexte
+    Alors je vois "Cette modération a été marqué comme traitée le"
+    Et je vois "Validé par user@yopmail.com"
+    Alors je vois "Liste des moderations"
+    Quand je clique sur "Voir les demandes traitées"
+    Quand je vais à l'intérieur de la rangée nommée "Modération a traiter de Jean Bon pour 51935970700022"
+    Et je clique sur "✅"
+    Et je réinitialise le contexte
+    Quand je clique sur "👥 1 membre connu dans l’organisation"
+    Alors je dois voir un tableau nommé "👥 1 membre connu dans l’organisation" et contenant
+      | Prénom | Nom  | Type               |
+      | Jean   | Bon  | <verification_enum> |
+
+    Exemples:
+      | type_verification           | verification_enum         |
+      | Mail officiel               | official_contact_email    |
+      | Liste des dirigeants RNA    | in_liste_dirigeants_rna   |
+      | Liste des dirigeants RNE    | in_liste_dirigeants_rne   |
+      | Justificatif transmis       | proof_received            |


### PR DESCRIPTION
<div align=center><img src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdDJpbGJhNzh6aDFhdWZ1Y3VhdDI3cDZuYjN2emtnbWNudWRzcjE5NyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/26tn33aiTi1jkl6H6/giphy.gif" /></div>

---

## Summary
• Add comprehensive e2e test for verification type selection in moderation modal
• Test all 4 verification types using Gherkin Examples pattern  
• Validate end-to-end flow from modal selection to member table display

## What's New
- **select_verification_type.feature** - Parameterized test covering all verification types
- **Updated CI matrix** - New test runs independently for better isolation
- **End-to-end validation** - Confirms verification enum values appear correctly in member table

## Verification Types Tested
• Mail officiel → `official_contact_email`
• Liste des dirigeants RNA → `in_liste_dirigeants_rna`  
• Liste des dirigeants RNE → `in_liste_dirigeants_rne`
• Justificatif transmis → `proof_received`

## Test Strategy
Uses Gherkin scenario outline with Examples table for clean, maintainable test coverage of the TagInput component functionality.